### PR TITLE
Update checkout action to v6

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -11,7 +11,7 @@ jobs:
   graphs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: upptime/uptime-monitor@v1.41.0
         with:
           command: "graphs"

--- a/.github/workflows/maintenance-site-refresh.yml
+++ b/.github/workflows/maintenance-site-refresh.yml
@@ -9,7 +9,7 @@ jobs:
   maintenance-site-refresh:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: upptime/uptime-monitor@v1.41.0
         with:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -11,7 +11,7 @@ jobs:
   response-time:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: upptime/uptime-monitor@v1.41.0
         with:
           command: "response-time"

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -11,7 +11,7 @@ jobs:
   static-site:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: upptime/uptime-monitor@v1.41.0
         with:

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -11,7 +11,7 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: upptime/uptime-monitor@v1.41.0
         with:
           command: "summary"

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -11,7 +11,7 @@ jobs:
   uptime:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: upptime/uptime-monitor@v1.41.0
         env:
           GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from `v4` to `v6` across status-page Upptime workflows.
- This removes the remaining Node.js 20-era GitHub Action usage in the status-page repo.

## Validation
- `git diff --check`
- Verified all workflow `actions/checkout` references now point to `v6`.
