### PR TITLE
Force status-page actions to Node 24

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/maintenance-site-refresh.yml
+++ b/.github/workflows/maintenance-site-refresh.yml
@@ -1,6 +1,9 @@
 name: Maintenance Site Refresh
 on:
   workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 23 * * *"
   workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## Summary
- Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` across status-page workflows.
- `actions/checkout` is now on v6, but the latest `upptime/uptime-monitor@v1.41.0` still runs on GitHub's Node 20 action runtime. Upstream has no newer release today, so this opts the workflows into GitHub's Node 24 action runtime ahead of the forced cutoff.

## Validation
- `git diff --check`
- Follow-up workflow dispatch will validate `Uptime CI` on this branch.
